### PR TITLE
Add support for LighTuning 1c7a:0584 (Acer Swift Go 14 OLED)   

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 
+## Debian 13 Package for Acer Swift Go 14 OLED
+**Maintainer:** Bikash Adhikari ([@bikashadhikari07](https://github.com/bikashadhikari07))
 
+This fork includes pre-compiled `.deb` packages specifically for Debian 13 (Trixie) users with the LighTuning 1c7a:0584 sensor.
+
+### Installation
+1. Download the `.deb` file from the [Releases](https://github.com/bikashadhikari07/libfprint-egismoc-sdcp/releases) page.
+2. Run: `sudo apt install ./libfprint-egismoc-1c7a_1.0-acer-swift-go_amd64.deb`
+3. Run: `fprintd-enroll`   
 <div align="center">
 
 # LibFPrint

--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 
-## Debian 13 Package for Acer Swift Go 14 OLED
-**Maintainer:** Bikash Adhikari ([@bikashadhikari07](https://github.com/bikashadhikari07))
 
-This fork includes pre-compiled `.deb` packages specifically for Debian 13 (Trixie) users with the LighTuning 1c7a:0584 sensor.
-
-### Installation
-1. Download the `.deb` file from the [Releases](https://github.com/bikashadhikari07/libfprint-egismoc-sdcp/releases) page.
-2. Run: `sudo apt install ./libfprint-egismoc-1c7a_1.0-acer-swift-go_amd64.deb`
-3. Run: `fprintd-enroll`   
 <div align="center">
 
 # LibFPrint
@@ -61,6 +53,15 @@ being shipped in an open source project.
  - [MailingList] - low traffic, not much used these days
 
 <br/>
+## Debian 13 Package for Acer Swift Go 14 OLED
+**Maintainer:** Bikash Adhikari ([@bikashadhikari07](https://github.com/bikashadhikari07))
+
+This fork includes pre-compiled `.deb` packages specifically for Debian 13 (Trixie) users with the LighTuning 1c7a:0584 sensor.
+
+### Installation
+1. Download the `.deb` file from the [Releases](https://github.com/bikashadhikari07/libfprint-egismoc-sdcp/releases) page.
+2. Run: `sudo apt install ./libfprint-egismoc-1c7a_1.0-acer-swift-go_amd64.deb`
+3. Run: `fprintd-enroll`   
 
 <div align="right">
 


### PR DESCRIPTION
This pull request adds support for the LighTuning Technology Inc. ETU905A88-E fingerprint sensor (USB ID `1c7a:0584`), commonly found on the Acer Swift Go 14 OLED.

**Device Details:**
- Model: LighTuning ETU905A88-E
- USB ID: `1c7a:0584`
- Found on: Acer Swift Go 14 OLED (SFG14-74)

**Testing:**
The changes have been tested on Debian 13 (Trixie). After building and installing the driver, the sensor is correctly detected, and `fprintd-enroll` and `fprintd-verify` work as expected.

This fix allows users of the Acer Swift Go 14 OLED to use fingerprint login on their Linux systems.   